### PR TITLE
fix: faker didn't work in pharo-11

### DIFF
--- a/src/Faker-Tests/FakerInternetTest.class.st
+++ b/src/Faker-Tests/FakerInternetTest.class.st
@@ -1,0 +1,16 @@
+"
+A FakerInternetTest is a test class for testing the behavior of FakerInternet
+"
+Class {
+	#name : #FakerInternetTest,
+	#superclass : #TestCase,
+	#category : #'Faker-Tests-Modules'
+}
+
+{ #category : #tests }
+FakerInternetTest >> testUrl [
+| url |
+	url := Faker new internet url.
+	self assert: [ url beginsWith: 'http' ]
+	description: 'Url produced in sot well formatted'
+]

--- a/src/Faker-Tests/FakerMultiplierTest.class.st
+++ b/src/Faker-Tests/FakerMultiplierTest.class.st
@@ -1,0 +1,19 @@
+"
+A FakerMultiplierTest is a test class for testing the behavior of FakerMultiplier
+"
+Class {
+	#name : #FakerMultiplierTest,
+	#superclass : #TestCase,
+	#category : #'Faker-Tests-Modules'
+}
+
+{ #category : #tests }
+FakerMultiplierTest >> testSampleOfSize [
+
+	| mult result |
+	mult := FakerMultiplier new.
+	mult target: [ 1 ].
+	result := mult sampleOfSize: 5.
+	self assert: [ result = #( 1 1 1 1 1) ]
+	description: 'The multiplier did not return the correct number of arguments'
+]

--- a/src/Faker-Tests/FakerTest.class.st
+++ b/src/Faker-Tests/FakerTest.class.st
@@ -1,0 +1,56 @@
+"
+A FakerTest is a test class for testing the behavior of Faker
+"
+Class {
+	#name : #FakerTest,
+	#superclass : #TestCase,
+	#category : #'Faker-Tests-Core'
+}
+
+{ #category : #tests }
+FakerTest >> testSampleOfSize [
+
+	| faker sample |
+	faker := Faker new.
+	sample := faker sample: #( 1 2 3 4 5 ) ofSize: 3.
+
+	self
+		assert: [ sample size = 3 ]
+		description: 'Sample produced was not of the required size'.
+
+
+	self
+		assert: [ (faker sample: #( 1 2 3 4 5 ) ofSize: 10) size = 10 ]
+		description:
+		'We couldnt create a collection bigger than the sample provided'
+]
+
+{ #category : #tests }
+FakerTest >> testSampleOfSizeWithCumulativeWeights [
+	| result | 
+	result := Faker new sample: #( 1 2 3 4) ofSize: 3 withCumulativeWeights: #(1 2 3).
+	self assert: [ result size = 3 ]
+	description: 'We saw a result produced that is not the size requested'
+]
+
+{ #category : #tests }
+FakerTest >> testUniqueSampleOfSize [
+
+	| faker sample |
+	faker := Faker new.
+	sample := faker uniqueSample: #( 1 2 3 4 5 ) ofSize: 3.
+
+	self
+		assert: [ sample size = 3 ]
+		description: 'Sample produced was not of the required size'.
+
+	self
+		assert: [ (Set newFrom: sample) size = sample size ]
+		description: 'The sample contained non-unique items'.
+
+	self
+		should: [ faker uniqueSample: #( 1 2 3 4 5 ) ofSize: 10 ]
+		raise: Error
+		description:
+		'This should error when the requested size is greater than the size of the sample'
+]

--- a/src/Faker-Tests/package.st
+++ b/src/Faker-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Faker-Tests' }

--- a/src/Faker/Faker.class.st
+++ b/src/Faker/Faker.class.st
@@ -231,22 +231,25 @@ Faker >> sample: aCollection [
 
 { #category : #actions }
 Faker >> sample: aCollection ofSize: aSize [
+
 	"Return a given numer of items from the collection.
 	Each value can be sampled multiple times."
+
 	<return: #Object>
-	self 
+	self
 		assert: [ aCollection isNotNil ]
 		description: [ 'Only collections can be sampled' ].
-	^ aSize timesCollect: [
-		self sample: aCollection ]
+
+	^ (1 to: aSize) collect: [ :_idx | self sample: aCollection ]
 ]
 
 { #category : #actions }
 Faker >> sample: aCollection ofSize: aSize withCumulativeWeights: aCollectionOfCumulativeWeights [
-	^ aSize timesCollect: [ 
-		self 
-			sample: aCollection 
-			withCumulativeWeights: aCollectionOfCumulativeWeights ]
+
+	^ (1 to: aSize) collect: [ :idx | 
+		  self
+			  sample: aCollection
+			  withCumulativeWeights: aCollectionOfCumulativeWeights ]
 ]
 
 { #category : #actions }
@@ -309,14 +312,23 @@ Faker >> sizeGenerator [
 
 { #category : #actions }
 Faker >> uniqueSample: aCollection ofSize: aSize [
+
 	"Return a given numer of items from the collection. 
 	Ensure every value is sampled at most once."
-	| indexes |
+
 	<return: #Object>
-	self 
+	| indexes |
+	
+	self
 		assert: [ aCollection isNotNil ]
 		description: [ 'Only collections can be sampled' ].
+
+	self
+		assert: [ aSize <= aCollection size ]
+		description:
+		'You can not create a result that is larger than the collection provided'.
+
 	indexes := self shuffle: (1 to: aCollection size) asOrderedCollection.
-	^ aSize timesCollect: [ :index |
-		aCollection at: (indexes at: index) ]
+
+	^ (1 to: aSize) collect: [ :idx | aCollection at: (indexes at: idx) ]
 ]

--- a/src/Faker/FakerEnLocales.class.st
+++ b/src/Faker/FakerEnLocales.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #FakerEnLocales,
 	#superclass : #FakerLocales,
+	#instVars : [
+		'internetDomainSuffixes'
+	],
 	#category : #'Faker-Locales'
 }
 
@@ -28,6 +31,84 @@ FakerEnLocales >> countryNamesAndIsoCodes [
 { #category : #country }
 FakerEnLocales >> countryNamesAndIsoCodesJsonString [
 	^ '[["Germany","DE"],["United Kingdom","UK"],["United States of America","US"],["Luxembourg","LU"],["Afghanistan","AF"],["Åland Islands","AX"],["Albania","AL"],["Algeria","DZ"],["American Samoa","AS"],["Andorra","AD"],["Angola","AO"],["Anguilla","AI"],["Antarctica","AQ"],["Antigua and Barbuda","AG"],["Argentina","AR"],["Armenia","AM"],["Aruba","AW"],["Australia","AU"],["Austria","AT"],["Azerbaijan","AZ"],["Bahamas","BS"],["Bahrain","BH"],["Bangladesh","BD"],["Barbados","BB"],["Belarus","BY"],["Belgium","BE"],["Belize","BZ"],["Benin","BJ"],["Bermuda","BM"],["Bhutan","BT"],["Bolivia (Plurinational State of)","BO"],["Bonaire, Sint Eustatius and Saba","BQ"],["Bosnia and Herzegovina","BA"],["Botswana","BW"],["Bouvet Island","BV"],["Brazil","BR"],["British Indian Ocean Territory","IO"],["Brunei Darussalam","BN"],["Bulgaria","BG"],["Burkina Faso","BF"],["Burundi","BI"],["Cabo Verde","CV"],["Cambodia","KH"],["Cameroon","CM"],["Canada","CA"],["Cayman Islands","KY"],["Central African Republic","CF"],["Chad","TD"],["Chile","CL"],["China","CN"],["Christmas Island","CX"],["Cocos (Keeling) Islands","CC"],["Colombia","CO"],["Comoros","KM"],["Congo","CG"],["Congo, Democratic Republic of the","CD"],["Cook Islands","CK"],["Costa Rica","CR"],["Côte d''Ivoire","CI"],["Croatia","HR"],["Cuba","CU"],["Curaçao","CW"],["Cyprus","CY"],["Czechia","CZ"],["Denmark","DK"],["Djibouti","DJ"],["Dominica","DM"],["Dominican Republic","DO"],["Ecuador","EC"],["Egypt","EG"],["El Salvador","SV"],["Equatorial Guinea","GQ"],["Eritrea","ER"],["Estonia","EE"],["Eswatini","SZ"],["Ethiopia","ET"],["Falkland Islands (Malvinas)","FK"],["Faroe Islands","FO"],["Fiji","FJ"],["Finland","FI"],["France","FR"],["French Guiana","GF"],["French Polynesia","PF"],["French Southern Territories","TF"],["Gabon","GA"],["Gambia","GM"],["Georgia","GE"],["Ghana","GH"],["Gibraltar","GI"],["Greece","GR"],["Greenland","GL"],["Grenada","GD"],["Guadeloupe","GP"],["Guam","GU"],["Guatemala","GT"],["Guernsey","GG"],["Guinea","GN"],["Guinea-Bissau","GW"],["Guyana","GY"],["Haiti","HT"],["Heard Island and McDonald Islands","HM"],["Holy See","VA"],["Honduras","HN"],["Hong Kong","HK"],["Hungary","HU"],["Iceland","IS"],["India","IN"],["Indonesia","ID"],["Iran (Islamic Republic of)","IR"],["Iraq","IQ"],["Ireland","IE"],["Isle of Man","IM"],["Israel","IL"],["Italy","IT"],["Jamaica","JM"],["Japan","JP"],["Jersey","JE"],["Jordan","JO"],["Kazakhstan","KZ"],["Kenya","KE"],["Kiribati","KI"],["Korea (Democratic People''s Republic of)","KP"],["Korea, Republic of","KR"],["Kuwait","KW"],["Kyrgyzstan","KG"],["Lao People''s Democratic Republic","LA"],["Latvia","LV"],["Lebanon","LB"],["Lesotho","LS"],["Liberia","LR"],["Libya","LY"],["Liechtenstein","LI"],["Lithuania","LT"],["Macao","MO"],["Madagascar","MG"],["Malawi","MW"],["Malaysia","MY"],["Maldives","MV"],["Mali","ML"],["Malta","MT"],["Marshall Islands","MH"],["Martinique","MQ"],["Mauritania","MR"],["Mauritius","MU"],["Mayotte","YT"],["Mexico","MX"],["Micronesia (Federated States of)","FM"],["Moldova, Republic of","MD"],["Monaco","MC"],["Mongolia","MN"],["Montenegro","ME"],["Montserrat","MS"],["Morocco","MA"],["Mozambique","MZ"],["Myanmar","MM"],["Namibia","NA"],["Nauru","NR"],["Nepal","NP"],["Netherlands","NL"],["New Caledonia","NC"],["New Zealand","NZ"],["Nicaragua","NI"],["Niger","NE"],["Nigeria","NG"],["Niue","NU"],["Norfolk Island","NF"],["North Macedonia","MK"],["Northern Mariana Islands","MP"],["Norway","NO"],["Oman","OM"],["Pakistan","PK"],["Palau","PW"],["Palestine, State of","PS"],["Panama","PA"],["Papua New Guinea","PG"],["Paraguay","PY"],["Peru","PE"],["Philippines","PH"],["Pitcairn","PN"],["Poland","PL"],["Portugal","PT"],["Puerto Rico","PR"],["Qatar","QA"],["Réunion","RE"],["Romania","RO"],["Russian Federation","RU"],["Rwanda","RW"],["Saint Barthélemy","BL"],["Saint Helena, Ascension and Tristan da Cunha","SH"],["Saint Kitts and Nevis","KN"],["Saint Lucia","LC"],["Saint Martin (French part)","MF"],["Saint Pierre and Miquelon","PM"],["Saint Vincent and the Grenadines","VC"],["Samoa","WS"],["San Marino","SM"],["Sao Tome and Principe","ST"],["Saudi Arabia","SA"],["Senegal","SN"],["Serbia","RS"],["Seychelles","SC"],["Sierra Leone","SL"],["Singapore","SG"],["Sint Maarten (Dutch part)","SX"],["Slovakia","SK"],["Slovenia","SI"],["Solomon Islands","SB"],["Somalia","SO"],["South Africa","ZA"],["South Georgia and the South Sandwich Islands","GS"],["South Sudan","SS"],["Spain","ES"],["Sri Lanka","LK"],["Sudan","SD"],["Suriname","SR"],["Svalbard and Jan Mayen","SJ"],["Sweden","SE"],["Switzerland","CH"],["Syrian Arab Republic","SY"],["Taiwan, Province of China","TW"],["Tajikistan","TJ"],["Tanzania, United Republic of","TZ"],["Thailand","TH"],["Timor-Leste","TL"],["Togo","TG"],["Tokelau","TK"],["Tonga","TO"],["Trinidad and Tobago","TT"],["Tunisia","TN"],["Turkey","TR"],["Turkmenistan","TM"],["Turks and Caicos Islands","TC"],["Tuvalu","TV"],["Uganda","UG"],["Ukraine","UA"],["United Arab Emirates","AE"],["United Kingdom of Great Britain and Northern Ireland","GB"],["United States Minor Outlying Islands","UM"],["Uruguay","UY"],["Uzbekistan","UZ"],["Vanuatu","VU"],["Venezuela (Bolivarian Republic of)","VE"],["Viet Nam","VN"],["Virgin Islands (British)","VG"],["Virgin Islands (U.S.)","VI"],["Wallis and Futuna","WF"],["Western Sahara","EH"],["Yemen","YE"],["Zambia","ZM"],["Zimbabwe","ZW"]]'
+]
+
+{ #category : #internet }
+FakerEnLocales >> defaultInternetDomainSuffixes [
+	^ #( 'com' 'info' 'name' 'net' 'org' 'io' 'edu' 'gov' 'biz' 'info' 'me' 'us' 'tv' )
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetCookieName [
+	^ self sample: self internetCookieNames
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetCookieNames [
+	^ #( 
+		'CONSENT' 
+		'NID' 
+		'OID'
+		'ANID' 
+		'PHPSESSID'
+		'SERVERID'
+		'__ga' 
+		'__cfduid' 
+		'__utma' 
+		'__gads' 
+		'__gid' 
+		'__user_id' 
+		'__ra'
+		'_fbp'
+		'sid' 
+		'cid'
+		'uid'
+		'utag_main'
+		'tuuid'
+		'euconsent'
+		'audit'
+	)
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetCookieValue [
+	^ self sample: self internetCookieValues
+]
+
+{ #category : #accessing }
+FakerEnLocales >> internetCookieValues [
+	^ { '1'. ''. 'true'. 'null'. '0'. 'de_DE'. 'yes'. 'EUR'. 'no'. 
+			self base numerify: '##########-############-#############-###'.
+			self base numerify: '##########.#####.########.########'.
+			self base numerify: '#######'.
+			self base numerify: '##.#####.#####-##########'.
+			self base numerify: '###.#################'. }
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetDomainSuffix [
+	^ self sample: self internetDomainSuffixes
+]
+
+{ #category : #accessing }
+FakerEnLocales >> internetDomainSuffixes [
+	^ internetDomainSuffixes ifNil: [ 
+		internetDomainSuffixes := self defaultInternetDomainSuffixes ]
+]
+
+{ #category : #accessing }
+FakerEnLocales >> internetDomainSuffixes: aCollectionOfSuffixes [
+	internetDomainSuffixes := aCollectionOfSuffixes
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetFreeEmailDomain [
+	^ self sample: self internetFreeEmailDomains
+]
+
+{ #category : #internet }
+FakerEnLocales >> internetFreeEmailDomains [
+	^ #( 'gmail.com' 'yahoo.com' 'hotmail.com' 'gmx.com' 'icloud.com' 'proton.me')
 ]
 
 { #category : #module }

--- a/src/Faker/FakerInternet.class.st
+++ b/src/Faker/FakerInternet.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FakerInternet,
 	#superclass : #FakerModule,
-	#category : 'Faker-Modules'
+	#category : #'Faker-Modules'
 }
 
 { #category : #cookie }
@@ -65,11 +65,13 @@ FakerInternet >> domainWord [
 
 { #category : #address }
 FakerInternet >> url [
+
 	<return: #String>
-	^ self 
-		urlScheme: 'https' 
-		host: self domainName 
-		path: ((self sample: (0 to: 6)) timesCollect: [ self username ])
+	| count path |
+	count := self sample: (0 to: 6).
+	path := (1 to: count) collect: [ :_idx | self username ].
+
+	^ self urlScheme: 'https' host: self domainName path: path
 ]
 
 { #category : #address }

--- a/src/Faker/FakerMultiplier.class.st
+++ b/src/Faker/FakerMultiplier.class.st
@@ -9,8 +9,8 @@ Class {
 
 { #category : #api }
 FakerMultiplier >> sampleOfSize: aSize [
-	^ aSize timesCollect: [ 
-		targetComputation value ]
+
+	^ (1 to: aSize) collect: [ :_idx | targetComputation value ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Pharo 11 doesn't have the `timesCollect` method. This fixes the instances where `timesCollect` was used and adds tests for those modified methods.

This didn't work in Pharo 11 and may not work in other versions. It looks like `timesCollect` was added to Glamourous Toolkit, but not ported back to Pharo.

This change also adds missing localizations for en_US.